### PR TITLE
add target version so upgrade rules can work on import

### DIFF
--- a/pxt.json
+++ b/pxt.json
@@ -19,5 +19,9 @@
     "supportedTargets": [
         "arcade"
     ],
+    "targetVersions": {
+        "target": "0.15.8",
+        "targetId": "arcade"
+    },
     "preferredEditor": "blocksprj"
 }


### PR DESCRIPTION
Hey, I figured out that there was actually no way to fix the import step of this completely at this point (barring a few complete hacks like hard coding a default version for github projects), so this is needed to make sure the blocks upgrade correctly. This is the PR that fixed this for future projects https://github.com/microsoft/pxt/pull/7345.

I'd note that the upgrade will likely work for your browser (after a version arcade containing https://github.com/microsoft/pxt/pull/7347 is pushed to beta and the target config cache is cleared, probably later today), as it stores version info once the project has been loaded into the editor; this PR only applies when someone is importing the project for the first time (e.g. someone sees your game on the forum and tries to download it.) No need to bump after merging, as import will pull the latest version from master (also, if you do make any changes before the arcade release from a non-beta branch, it's possible the pxt.json update logic will remove this field / this fix would need to add it back in manually)